### PR TITLE
Use Maven variable for output folder in allure.results.directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
                 </configuration>
             </plugin>
         </plugins>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
     </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
         <junit.platform.version>1.3.1</junit.platform.version>
         <aspectj.version>1.9.5</aspectj.version>
-        <allure.version>2.13.2</allure.version>
+        <allure.version>2.13.3</allure.version>
     </properties>
 
     <dependencies>

--- a/src/test/resources/allure.properties
+++ b/src/test/resources/allure.properties
@@ -1,1 +1,1 @@
-allure.results.directory=target/allure-results
+allure.results.directory=${project.build.directory}/allure-results


### PR DESCRIPTION
Add testResources folder with resource filtering and change hard-coded target/ folder to use maven project variable `${project.build.directory}` in allure.results.directory=${project.build.directory}/allure-results

Bonus: bump allure2 version to 2.13.3